### PR TITLE
Feat/#7 : 페이지네이션

### DIFF
--- a/GitHubSearchApp_iOS_TCA/Sources/GitHubSearchAppComponent/GitHubSearch/Store/GitHubSearchStore.swift
+++ b/GitHubSearchApp_iOS_TCA/Sources/GitHubSearchAppComponent/GitHubSearch/Store/GitHubSearchStore.swift
@@ -13,7 +13,7 @@ struct GitHubSearchStore: ReducerProtocol {
   
   struct State: Equatable {
     @BindingState var searchQuery = ""
-    var currentPage = 0
+    var currentPage = 1
     var isLoading = false
     var searchResults: [Repository] = []
   }
@@ -37,11 +37,11 @@ struct GitHubSearchStore: ReducerProtocol {
         guard !state.searchQuery.isEmpty else {
           return .none
         }
-        state.currentPage = 0
+        state.currentPage = 1
         state.isLoading = true
         return .task { [query = state.searchQuery] in
           await .searchResponse(TaskResult {
-            await self.gitHubSearchClient.fetchData(query, 0)
+            await self.gitHubSearchClient.fetchData(query, 1)
           })
         }
         

--- a/GitHubSearchApp_iOS_TCA/Sources/GitHubSearchAppComponent/GitHubSearch/Views/GitHubSearchListView.swift
+++ b/GitHubSearchApp_iOS_TCA/Sources/GitHubSearchAppComponent/GitHubSearch/Views/GitHubSearchListView.swift
@@ -18,6 +18,17 @@ struct GitHubSearchListView: View {
           ForEach(viewStore.searchResults) { repo in
             GitHubSearchListRowView(repository: repo)
           }
+          
+          if !viewStore.searchResults.isEmpty {
+            HStack {
+              Spacer()
+              ProgressView()
+                .onAppear {
+                  print("execute pagination")
+                }
+              Spacer()
+            }
+          }
         }
         .navigationTitle("GitHubSearch")
         .searchable(text: viewStore.binding(\.$searchQuery))

--- a/GitHubSearchApp_iOS_TCA/Sources/GitHubSearchAppComponent/GitHubSearch/Views/GitHubSearchListView.swift
+++ b/GitHubSearchApp_iOS_TCA/Sources/GitHubSearchAppComponent/GitHubSearch/Views/GitHubSearchListView.swift
@@ -24,7 +24,7 @@ struct GitHubSearchListView: View {
               Spacer()
               ProgressView()
                 .onAppear {
-                  print("execute pagination")
+                  viewStore.send(.paginationRepo)
                 }
               Spacer()
             }

--- a/GitHubSearchApp_iOS_TCA/Sources/Infrastructure/Network/Provider/Provider.swift
+++ b/GitHubSearchApp_iOS_TCA/Sources/Infrastructure/Network/Provider/Provider.swift
@@ -14,8 +14,6 @@ protocol URLSessionable {
 extension URLSession: URLSessionable {}
 
 
-
-
 protocol Provider {
   func request<E: RequestResponsable, R: Decodable>(endpoint: E)
   async -> Result<R, NetworkError>

--- a/Tests/GitHubSearchAppComponentTests/GitHubSearch/Store/GitHubSearchStoreTests.swift
+++ b/Tests/GitHubSearchAppComponentTests/GitHubSearch/Store/GitHubSearchStoreTests.swift
@@ -27,9 +27,10 @@ final class GitHubSearchStoreTests: XCTestCase {
   func testSearchRepo() async {
     // given, when
     let testSearchText = "123"
+    
     let store = TestStore(initialState: GitHubSearchStore.State(),
                           reducer: GitHubSearchStore()) { testDependency in
-      testDependency.gitHubSearchClient.search = { _ in
+      testDependency.gitHubSearchClient.fetchData = { _, _ in
         return Repository.mockRepoList(testSearchText.count)
       }
     }
@@ -38,12 +39,15 @@ final class GitHubSearchStoreTests: XCTestCase {
       $0.searchQuery = testSearchText
     }
     
-    await store.send(.searchRepo)
+    await store.send(.searchRepo) {
+      $0.isLoading = true
+    }
     
     await store.receive(.searchResponse(.success(
       Repository.mockRepoList(testSearchText.count)
     ))) {
       $0.searchResults = Repository.mockRepoList(testSearchText.count)
+      $0.isLoading = false
     }
   }
 }

--- a/Tests/GitHubSearchAppComponentTests/GitHubSearch/Store/GitHubSearchStoreTests.swift
+++ b/Tests/GitHubSearchAppComponentTests/GitHubSearch/Store/GitHubSearchStoreTests.swift
@@ -55,7 +55,7 @@ final class GitHubSearchStoreTests: XCTestCase {
     let testSearchText = "123"
     let mockRepoList = Repository.mockRepoList(testSearchText.count)
     let store = TestStore(initialState: GitHubSearchStore.State(searchQuery: testSearchText,
-                                                                currentPage: 1,
+                                                                currentPage: 2,
                                                                 searchResults: mockRepoList
                                                                ),
                           reducer: GitHubSearchStore()) { testDependency in
@@ -67,7 +67,7 @@ final class GitHubSearchStoreTests: XCTestCase {
     // then
     await store.send(.paginationRepo) {
       $0.isLoading = true
-      $0.currentPage = 2
+      $0.currentPage = 3
     }
     
     await store.receive(.paginationResponse(.success(mockRepoList))) {


### PR DESCRIPTION
## 🛠 변경사항 및 구현한 기능
- #7 

## 🙌 해결한 방법
``` swift
List {
          ForEach(viewStore.searchResults) { repo in
            GitHubSearchListRowView(repository: repo)
          }
          
          if !viewStore.searchResults.isEmpty {
            HStack {
              Spacer()
              ProgressView()
                .onAppear {
                  viewStore.send(.paginationRepo)
                }
              Spacer()
            }
          }
        }
```
List 하단에 ProgressView 배치, onAppear 할때마다 페이지네이션 진행