### PR TITLE
[Fix] : coredata remove 실행시 색상 매칭 바로 반영하게 변경

### DIFF
--- a/GitHubSearchApp_iOS_TCA/Sources/GitHubSearchAppComponent/Dependency/GitHubSearchClient.swift
+++ b/GitHubSearchApp_iOS_TCA/Sources/GitHubSearchAppComponent/Dependency/GitHubSearchClient.swift
@@ -36,7 +36,7 @@ extension GitHubSearchClient: DependencyKey {
     },
     
     removeRepoInCoreData: { repo in
-      let isSuccess = await CoreDataManager.shared.remove(repo) == nil ? nil : false
+      let isSuccess = await CoreDataManager.shared.remove(repo) == nil ? false : nil
       return isSuccess
     },
     

--- a/GitHubSearchApp_iOS_TCA/Sources/GitHubSearchAppComponent/View/GitHubSearch/Stores/GitHubSearchRowStore.swift
+++ b/GitHubSearchApp_iOS_TCA/Sources/GitHubSearchAppComponent/View/GitHubSearch/Stores/GitHubSearchRowStore.swift
@@ -39,13 +39,8 @@ struct GitHubSearchRowStore: ReducerProtocol {
       
     case .tapStarButton:
       return .task { [repo = state.repo, isStore = state.starButtonState] in
-        if !isStore {
-          let isSuccess = await gitHubSearchClient.addToCoreData(repo)
-          return .toggleStarButtonState(isSuccess: isSuccess)
-        } else {
-          let isSuccess = await gitHubSearchClient.removeRepoInCoreData(repo)
-          return .toggleStarButtonState(isSuccess: isSuccess)
-        }
+        let isSuccess = await isStore ? gitHubSearchClient.removeRepoInCoreData(repo) : gitHubSearchClient.addToCoreData(repo)
+        return .toggleStarButtonState(isSuccess: isSuccess)
       }
       
     case .showSafari:

--- a/GitHubSearchApp_iOS_TCA/Sources/GitHubSearchAppComponent/View/GitHubSearch/Stores/GitHubSearchStore.swift
+++ b/GitHubSearchApp_iOS_TCA/Sources/GitHubSearchAppComponent/View/GitHubSearch/Stores/GitHubSearchStore.swift
@@ -88,10 +88,10 @@ struct GitHubSearchStore: ReducerProtocol {
         state.isLoading = false
         return .none
         
-      case .forEachRepos(id: let id, action: .tapStarButton):
+      case .forEachRepos(id: _, action: .tapStarButton):
         return .none
         
-      case .forEachRepos(id: let id, action: .toggleStarButtonState):
+      case .forEachRepos(id: _, action: .toggleStarButtonState):
         return .none
         
       case .forEachRepos(id: let id, action: .showSafari):

--- a/GitHubSearchApp_iOS_TCA/Sources/GitHubSearchAppComponent/View/MyRepo/Stores/MyRepoListStore.swift
+++ b/GitHubSearchApp_iOS_TCA/Sources/GitHubSearchAppComponent/View/MyRepo/Stores/MyRepoListStore.swift
@@ -9,6 +9,8 @@ import ComposableArchitecture
 import Foundation
 
 struct MyRepoListStore: ReducerProtocol {
+  @Dependency(\.gitHubSearchClient) var gitHubSearchClient
+  
   struct State: Equatable {
     var url: URL? = nil
     @BindingState var showSafari = false
@@ -17,6 +19,7 @@ struct MyRepoListStore: ReducerProtocol {
   enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
     case tapListCell(selectedItem: Repository)
+    case tapStarButton(selectedItem: Repository)
   }
   
   var body: some ReducerProtocol<State, Action> {
@@ -30,6 +33,12 @@ struct MyRepoListStore: ReducerProtocol {
         if let url = URL(string: selectedRepo.urlString) {
           state.url = url
           state.showSafari.toggle()
+        }
+        return .none
+        
+      case .tapStarButton(let selectedRepo):
+        Task {
+          await gitHubSearchClient.removeRepoInCoreData(selectedRepo)
         }
         return .none
       }

--- a/GitHubSearchApp_iOS_TCA/Sources/GitHubSearchAppComponent/View/MyRepo/Views/MyRepoListView.swift
+++ b/GitHubSearchApp_iOS_TCA/Sources/GitHubSearchAppComponent/View/MyRepo/Views/MyRepoListView.swift
@@ -15,13 +15,15 @@ struct MyRepoListView: View {
   
   let store: StoreOf<MyRepoListStore>
   
+  
+  
   var body: some View {
     WithViewStore(store, observe: { $0 }) { viewStore in
       NavigationView {
         List {
           ForEach(myRepos) { myRepo in
             if let repo = myRepo.toDomain() {
-              myRepoRow(repo)
+              myRepoRow(repo: repo, viewStore: viewStore)
                 .onTapGesture {
                   viewStore.send(.tapListCell(selectedItem: repo))
                 }
@@ -37,8 +39,11 @@ struct MyRepoListView: View {
       }
     }
   }
-
-  func myRepoRow(_ repo: Repository) -> some View {
+  
+  func myRepoRow(
+    repo: Repository,
+    viewStore: ViewStore<MyRepoListStore.State, MyRepoListStore.Action>
+  ) -> some View {
     HStack {
       VStack(alignment: .leading) {
         Text(repo.name)
@@ -50,9 +55,11 @@ struct MyRepoListView: View {
       
       VStack {
         Button {
-          Task {
-            let removeError = await CoreDataManager.shared.remove(repo)
-          }
+//          Task {
+////            let removeError = await CoreDataManager.shared.remove(repo)
+//            
+//          }
+          viewStore.send(.tapStarButton(selectedItem: repo))
         } label: {
           Image(systemName: "star.fill")
         }


### PR DESCRIPTION
## 🛠 변경사항 및 구현한 기능
- #15 

## 🙌 해결한 방법
``` swift
// GitHubSearchClient.swift
 removeRepoInCoreData: { repo in
      let isSuccess = await CoreDataManager.shared.remove(repo) == nil ? false : nil
      return isSuccess
    },
```